### PR TITLE
Add jive install instructions

### DIFF
--- a/Do/bail.do
+++ b/Do/bail.do
@@ -28,6 +28,8 @@ ivregress 2sls guilt (jail3= $judge_pre) $control2, robust first
 ivregress 2sls guilt (jail3= $judge_pre) possess robbery DUI1st drugSell aggAss $demo $prior $off $control2 , robust first
 
 * JIVE main results
+* jive can be installed using: net install st0108
+
 * minimum controls
 jive guilt (jail3= $judge_pre) $control2, robust
 * maximum controls


### PR DESCRIPTION
For an intro textbook I think expecting students to figure out how to search the Stata Journal using `net` and then `net install` the corresponding package is a little harsh.

Maybe I'm a complete Stata noob and it's actually very easy however.